### PR TITLE
Fixing bundler dependency problem with rails 3.1.0

### DIFF
--- a/render_component_vho.gemspec
+++ b/render_component_vho.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{render_component_vho}
-  s.version = "3.1.0"
+  s.version = "3.1.0.rc1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["David Heinemeier Hansson"]
@@ -49,20 +49,20 @@ Gem::Specification.new do |s|
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
-      s.add_runtime_dependency(%q<railties>, ["~> 3.1.0"])
+      s.add_runtime_dependency(%q<railties>, ["~> 3.1.0.rc1"])
     else
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
       s.add_dependency(%q<rcov>, [">= 0"])
-      s.add_dependency(%q<railties>, ["~> 3.1.0"])
+      s.add_dependency(%q<railties>, ["~> 3.1.0.rc1"])
     end
   else
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])
     s.add_dependency(%q<jeweler>, ["~> 1.5.2"])
     s.add_dependency(%q<rcov>, [">= 0"])
-    s.add_dependency(%q<railties>, ["~> 3.1.0"])
+    s.add_dependency(%q<railties>, ["~> 3.1.0.rc1"])
   end
 end
 


### PR DESCRIPTION
I simply changed '3.1.0' with '3.1.0.rc1', and this removed by bundle install errors. I am using rails 3.1.0.rc6.

A similar change is also required in active_scaffold.
