### PR TITLE
Strange bug fixed

### DIFF
--- a/lib/render_component/components.rb
+++ b/lib/render_component/components.rb
@@ -118,6 +118,7 @@ module RenderComponent
 
             request.env.select {|key, value| key == key.upcase || key == 'rack.input'}.each {|item| request_env[item[0]] = item[1]}
 
+            request_env['REQUEST_METHOD'] = "GET"
             request_env['REQUEST_URI'] = url_for(options)
             request_env["PATH_INFO"] = url_for(options.merge(:only_path => true))
             request_env["action_dispatch.request.symbolized_path_parameters"] = request_params


### PR DESCRIPTION
All requests should be get, it was failing due to forgering protection when a post request use render_component

For example using render :active_scaffold in the layout, when a post request fails due to validation errors, render_component fails due to forgery protection, clears your session, and it will logout you for example.
